### PR TITLE
Access cmeps 1.0.25

### DIFF
--- a/mediator/CMakeLists.txt
+++ b/mediator/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(cmeps Fortran)
 
-set(SRCFILES esmFldsExchange_cesm_mod.F90 med_fraction_mod.F90
+set(SRCFILES esmFldsExchange_access_mod.F90 esmFldsExchange_cesm_mod.F90 med_fraction_mod.F90
               med_methods_mod.F90 med_phases_prep_ice_mod.F90
               med_phases_restart_mod.F90 esmFldsExchange_hafs_mod.F90
               med_internalstate_mod.F90 med_phases_aofluxes_mod.F90

--- a/mediator/Makefile
+++ b/mediator/Makefile
@@ -36,13 +36,14 @@ esmFlds.o : med_kind_mod.o
 esmFldsExchange_cesm_mod.o : med_kind_mod.o med_methods_mod.o esmFlds.o med_internalstate_mod.o med_utils_mod.o
 esmFldsExchange_nems_mod.o : med_kind_mod.o med_methods_mod.o esmFlds.o med_internalstate_mod.o med_utils_mod.o
 esmFldsExchange_hafs_mod.o : med_kind_mod.o med_methods_mod.o esmFlds.o med_internalstate_mod.o med_utils_mod.o
+esmFldsExchange_access_mod.o : med_kind_mod.o med_methods_mod.o esmFlds.o med_internalstate_mod.o med_utils_mod.o
 med.o : med_kind_mod.o med_phases_profile_mod.o med_utils_mod.o med_phases_prep_rof_mod.o med_phases_aofluxes_mod.o \
    med_phases_prep_ice_mod.o med_fraction_mod.o med_map_mod.o med_constants_mod.o med_phases_prep_wav_mod.o \
    med_phases_prep_lnd_mod.o med_phases_history_mod.o med_phases_ocnalb_mod.o med_phases_restart_mod.o \
    med_time_mod.o med_internalstate_mod.o med_phases_prep_atm_mod.o esmFldsExchange_cesm_mod.o esmFldsExchange_nems_mod.o \
-   esmFldsExchange_hafs_mod.o med_phases_prep_glc_mod.o esmFlds.o med_io_mod.o med_methods_mod.o med_phases_prep_ocn_mod.o \
-   med_phases_post_atm_mod.o med_phases_post_ice_mod.o med_phases_post_lnd_mod.o med_phases_post_glc_mod.o med_phases_post_rof_mod.o \
-   med_phases_post_wav_mod.o
+   esmFldsExchange_hafs_mod.o esmFldsExchange_access_mod.o med_phases_prep_glc_mod.o esmFlds.o med_io_mod.o med_methods_mod.o \
+   med_phases_prep_ocn_mod.o med_phases_post_atm_mod.o med_phases_post_ice_mod.o med_phases_post_lnd_mod.o med_phases_post_glc_mod.o \
+   med_phases_post_rof_mod.o med_phases_post_wav_mod.o
 med_fraction_mod.o : med_kind_mod.o med_utils_mod.o med_internalstate_mod.o med_constants_mod.o med_map_mod.o med_methods_mod.o esmFlds.o
 med_internalstate_mod.o : med_kind_mod.o esmFlds.o
 med_io_mod.o : med_kind_mod.o med_methods_mod.o med_constants_mod.o med_internalstate_mod.o med_utils_mod.o

--- a/mediator/esmFldsExchange_access_mod.F90
+++ b/mediator/esmFldsExchange_access_mod.F90
@@ -465,14 +465,14 @@ module esmFldsExchange_access_mod
 
       ! precip
       call addmap_from(compatm, 'Faxa_rainc', compocn, mapconsf, 'one', 'unset') ! TODO: weight by ocean fraction
-      call addmrg_to(compocn, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainc', mrg_type='sum')
+      call addmrg_to(compocn, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainc', mrg_type='sum_with_weights', mrg_fracname='ofrac')
       call addmap_from(compatm, 'Faxa_rainl', compocn, mapconsf, 'one', 'unset')
-      call addmrg_to(compocn, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainl', mrg_type='sum')
+      call addmrg_to(compocn, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainl', mrg_type='sum_with_weights', mrg_fracname='ofrac')
 
       call addmap_from(compatm, 'Faxa_snowc', compocn, mapconsf, 'one', 'unset')
-      call addmrg_to(compocn, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowc', mrg_type='sum')
+      call addmrg_to(compocn, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowc', mrg_type='sum_with_weights', mrg_fracname='ofrac')
       call addmap_from(compatm, 'Faxa_snowl', compocn, mapconsf, 'one', 'unset')
-      call addmrg_to(compocn, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowl', mrg_type='sum')
+      call addmrg_to(compocn, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowl', mrg_type='sum_with_weights', mrg_fracname='ofrac')
       
       ! from ice
       call addmap_from(compice, 'Si_ifrac', compocn, mapfcopy, 'unset', 'unset')

--- a/mediator/esmFldsExchange_access_mod.F90
+++ b/mediator/esmFldsExchange_access_mod.F90
@@ -549,12 +549,19 @@ module esmFldsExchange_access_mod
       ! ---------------------------------------------------------------------
 
       ! from atm
-      allocate(F_flds(5, 2))
+      allocate(F_flds(12, 2))
       F_flds(1,:) = (/'Faxa_swvdr ', 'Faxa_swvdr '/)
       F_flds(2,:) = (/'Faxa_swndr ', 'Faxa_swndr '/)
       F_flds(3,:) = (/'Faxa_swvdf', 'Faxa_swvdf'/)
       F_flds(4,:) = (/'Faxa_swndf', 'Faxa_swndf'/)
       F_flds(5,:) = (/'Faxa_lwdn', 'Faxa_lwdn'/)
+      F_flds(6,:) = (/'pen_rad', 'pen_rad'/)
+      F_flds(7,:) = (/'topmelt', 'topmelt'/)
+      F_flds(8,:) = (/'botmelt', 'botmelt'/)
+      F_flds(9,:) = (/'tstar_sice', 'tstar_sice'/)
+      F_flds(10,:) = (/'sublim', 'sublim'/)
+      F_flds(11,:) = (/'Foxx_sen', 'Foxx_sen'/)
+      F_flds(12,:) = (/'Faxa_swdn', 'Faxa_swdn'/)
 
       do n = 1,size(F_flds,1)
          fldname1 = trim(F_flds(n,1))

--- a/mediator/esmFldsExchange_access_mod.F90
+++ b/mediator/esmFldsExchange_access_mod.F90
@@ -267,14 +267,20 @@ module esmFldsExchange_access_mod
       ! ---------------------------------------------------------------------
       ! to ice: flux fields
       ! ---------------------------------------------------------------------
-      allocate(F_flds(7, 2))
+
+      allocate(F_flds(12, 2))
       F_flds(1,:) = (/'Faxa_swvdr ', 'Faxa_swvdr '/)
       F_flds(2,:) = (/'Faxa_swndr ', 'Faxa_swndr '/)
       F_flds(3,:) = (/'Faxa_swvdf', 'Faxa_swvdf'/)
       F_flds(4,:) = (/'Faxa_swndf', 'Faxa_swndf'/)
       F_flds(5,:) = (/'Faxa_lwdn', 'Faxa_lwdn'/)
-      F_flds(6,:) = (/'Faxa_rainl', 'Faxa_rain'/)
-      F_flds(7,:) = (/'Faxa_snowl', 'Faxa_snow'/)
+      F_flds(6,:) = (/'pen_rad', 'pen_rad'/)
+      F_flds(7,:) = (/'topmelt', 'topmelt'/)
+      F_flds(8,:) = (/'botmelt', 'botmelt'/)
+      F_flds(9,:) = (/'tstar_sice', 'tstar_sice'/)
+      F_flds(10,:) = (/'sublim', 'sublim'/)
+      F_flds(11,:) = (/'Foxx_sen', 'Foxx_sen'/)
+      F_flds(12,:) = (/'Faxa_swdn', 'Faxa_swdn'/)
       do n = 1,size(F_flds,1)
          fldname1 = trim(F_flds(n,1))
          fldname2 = trim(F_flds(n,2))
@@ -285,6 +291,11 @@ module esmFldsExchange_access_mod
 
       call addfld_from(compatm, 'Faxa_rainc')
       call addfld_from(compatm, 'Faxa_snowc')
+      call addfld_from(compatm, 'Faxa_rainl')
+      call addfld_from(compatm, 'Faxa_snowl')
+
+      call addfld_to(compice, 'Faxa_rain')
+      call addfld_to(compice, 'Faxa_snow')
       
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
 

--- a/mediator/esmFldsExchange_access_mod.F90
+++ b/mediator/esmFldsExchange_access_mod.F90
@@ -131,8 +131,8 @@ module esmFldsExchange_access_mod
       ! ---------------------------------------------------------------------
       ! to atm: from ocn
       ! ---------------------------------------------------------------------
-      allocate(S_flds(1))
-      S_flds = (/'So_t'/) ! sea_surface_temperature
+      allocate(S_flds(3))
+      S_flds = (/'So_t', 'So_u', 'So_v'/) ! sea_surface_temperature
       do n = 1,size(S_flds)
         fldname = trim(S_flds(n))
         call addfld_from(compocn, trim(fldname))
@@ -395,6 +395,10 @@ module esmFldsExchange_access_mod
       ! ---------------------------------------------------------------------
       call addmap_from(compocn, 'So_t', compatm, mapconsf, 'ofrac', 'unset')
       call addmrg_to(compatm, 'So_t', mrg_from=compocn, mrg_fld='So_t', mrg_type='copy')
+      call addmap_from(compocn, 'So_u', compatm, mapconsf, 'ofrac', 'unset')
+      call addmrg_to(compatm, 'So_u', mrg_from=compocn, mrg_fld='So_u', mrg_type='copy')
+      call addmap_from(compocn, 'So_v', compatm, mapconsf, 'ofrac', 'unset')
+      call addmrg_to(compatm, 'So_v', mrg_from=compocn, mrg_fld='So_v', mrg_type='copy')
 
       call addmap_from(compice, 'Si_t', compatm, mapconsd, 'ifrac', 'unset')
       call addmrg_to(compatm, 'Si_t', mrg_from=compice, mrg_fld='Si_t', mrg_type='copy')

--- a/mediator/esmFldsExchange_access_mod.F90
+++ b/mediator/esmFldsExchange_access_mod.F90
@@ -154,8 +154,8 @@ module esmFldsExchange_access_mod
                   'ia_pndtn'/) ! sea_surface_temperature
       do n = 1,size(S_flds)
         fldname = trim(S_flds(n))
-        call addfld(fldListFr(compice)%flds, trim(fldname))
-        call addfld(fldListTo(compatm)%flds, trim(fldname))
+        call addfld_from(compice, trim(fldname))
+        call addfld_to(compatm, trim(fldname))
       end do
       deallocate(S_flds)
 
@@ -392,8 +392,8 @@ module esmFldsExchange_access_mod
                   'ia_pndtn'/) ! sea_surface_temperature
       do n = 1,size(S_flds)
         fldname = trim(S_flds(n))
-        call addmap(fldListFr(compice)%flds, trim(fldname), compatm, mapconsf, 'ifrac', 'unset')
-        call addmrg(fldListTo(compatm)%flds, trim(fldname), mrg_from=compice, mrg_fld=trim(fldname), mrg_type='copy')
+        call addmap_from(compice, trim(fldname), compatm, mapconsf, 'ifrac', 'unset')
+        call addmrg_to(compatm, trim(fldname), mrg_from=compice, mrg_fld=trim(fldname), mrg_type='copy')
       end do
       deallocate(S_flds)
       ! call addmap(fldListFr(compice)%flds, 'Si_t', compatm, mapconsf, 'ifrac', 'unset')

--- a/mediator/esmFldsExchange_access_mod.F90
+++ b/mediator/esmFldsExchange_access_mod.F90
@@ -1,0 +1,564 @@
+module esmFldsExchange_access_mod
+
+    use ESMF
+    use NUOPC
+    use med_utils_mod         , only : chkerr => med_utils_chkerr
+    use med_kind_mod          , only : CX=>SHR_KIND_CX
+    use med_kind_mod          , only : CS=>SHR_KIND_CS
+    use med_kind_mod          , only : CL=>SHR_KIND_CL
+    use med_kind_mod          , only : R8=>SHR_KIND_R8
+    use med_internalstate_mod , only : compmed, compatm, compocn, compwav, compice
+    use med_internalstate_mod , only : ncomps
+    use med_internalstate_mod , only : coupling_mode
+    use esmflds               , only : fldListTo
+    use esmflds               , only : fldListFr
+
+    !---------------------------------------------------------------------
+    ! This is a mediator specific routine that determines ALL possible
+    ! fields exchanged between components and their associated routing,
+    ! mapping and merging
+    !---------------------------------------------------------------------
+
+    implicit none
+    public
+
+    public :: esmFldsExchange_access
+
+    character(*), parameter :: u_FILE_u = &
+         __FILE__
+
+  !===============================================================================
+  contains
+  !===============================================================================
+
+    subroutine esmFldsExchange_access(gcomp, phase, rc)
+
+      ! input/output parameters:
+      type(ESMF_GridComp)              :: gcomp
+      character(len=*) , intent(in)    :: phase
+      integer          , intent(inout) :: rc
+
+      ! local variables:
+      character(len=*) , parameter   :: subname='(esmFldsExchange_access)'
+      !--------------------------------------
+
+      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
+      rc = ESMF_SUCCESS
+
+      if (phase == 'advertise') then
+        call esmFldsExchange_access_advt(gcomp, phase, rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+      elseif (phase == 'fieldcheck') then
+        call esmFldsExchange_access_fchk(gcomp, phase, rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+      elseif (phase == 'initialize') then
+        call esmFldsExchange_access_init(gcomp, phase, rc)
+        if (chkerr(rc,__LINE__,u_FILE_u)) return
+      else
+        call ESMF_LogSetError(ESMF_FAILURE, &
+           msg=trim(subname)//": Phase is set to "//trim(phase), &
+           line=__LINE__, file=__FILE__, rcToReturn=rc)
+        return  ! bail out
+      endif
+
+      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
+
+    end subroutine esmFldsExchange_access
+
+    !-----------------------------------------------------------------------------
+
+    subroutine esmFldsExchange_access_advt(gcomp, phase, rc)
+
+      use esmFlds, only : addfld => med_fldList_AddFld
+
+      ! input/output parameters:
+      type(ESMF_GridComp)              :: gcomp
+      character(len=*) , intent(in)    :: phase
+      integer          , intent(inout) :: rc
+
+      ! local variables:
+      integer             :: num, i, n
+      logical             :: isPresent
+      character(len=CL)   :: cvalue
+      character(len=CS)   :: name, fldname
+      character(len=CS)   :: fldname1, fldname2
+      character(len=CS), allocatable :: flds(:)
+      character(len=CS), allocatable :: S_flds(:)
+      character(len=CS), allocatable :: F_flds(:,:)
+      character(len=CS), allocatable :: suffix(:)
+      character(len=*) , parameter   :: subname='(esmFldsExchange_access_advt)'
+      !--------------------------------------
+
+      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
+      rc = ESMF_SUCCESS
+
+      !=====================================================================
+      ! scalar information
+      !=====================================================================
+
+      call NUOPC_CompAttributeGet(gcomp, name='ScalarFieldName', &
+         isPresent=isPresent, rc=rc)
+      if (chkerr(rc,__LINE__,u_FILE_u)) return
+      if (isPresent) then
+         call NUOPC_CompAttributeGet(gcomp, name="ScalarFieldName", &
+            value=cvalue, rc=rc)
+         if (ChkErr(rc,__LINE__,u_FILE_u)) return
+         do n = 1,ncomps
+            call addfld(fldListFr(n)%flds, trim(cvalue))
+            call addfld(fldListTo(n)%flds, trim(cvalue))
+         end do
+      end if
+
+
+      !=====================================================================
+      ! FIELDS TO MEDIATOR component (for fractions and atm/ocn flux calculation)
+      !=====================================================================
+
+      !----------------------------------------------------------
+      ! to med: masks from components
+      !----------------------------------------------------------
+      call addfld(fldListFr(compocn)%flds, 'So_omask')
+      call addfld(fldListFr(compice)%flds, 'Si_imask')
+
+      !=====================================================================
+      ! FIELDS TO ATMOSPHERE
+      !=====================================================================
+
+      call addfld(fldListTo(compatm)%flds, 'So_ofrac')
+      call addfld(fldListTo(compatm)%flds, 'Si_ifrac')
+
+      ! ---------------------------------------------------------------------
+      ! to atm: from ocn
+      ! ---------------------------------------------------------------------
+      allocate(S_flds(1))
+      S_flds = (/'So_t'/) ! sea_surface_temperature
+      do n = 1,size(S_flds)
+        fldname = trim(S_flds(n))
+        call addfld(fldListFr(compocn)%flds, trim(fldname))
+        call addfld(fldListTo(compatm)%flds, trim(fldname))
+      end do
+      deallocate(S_flds)
+
+      ! ---------------------------------------------------------------------
+      ! to atm: from ice
+      ! ---------------------------------------------------------------------
+      call addfld(fldListFr(compice)%flds, 'Si_t')
+      call addfld(fldListTo(compatm)%flds, 'Si_t')
+
+      !=====================================================================
+      ! FIELDS TO OCEAN (compocn)
+      !=====================================================================
+
+      ! ---------------------------------------------------------------------
+      ! to ocn: state fields
+      ! ---------------------------------------------------------------------
+      allocate(S_flds(2))
+      S_flds = (/'Sa_pslv', & ! inst_zonal_wind_height10m
+                  'So_duu10n' /) ! inst_temp_height_surface
+      do n = 1,size(S_flds)
+         fldname = trim(S_flds(n))
+         call addfld(fldListFr(compatm)%flds, trim(fldname))
+         call addfld(fldListTo(compocn)%flds, trim(fldname))
+      end do
+      deallocate(S_flds)
+
+      ! ---------------------------------------------------------------------
+      ! to ocn: flux fields
+      ! ---------------------------------------------------------------------
+
+      ! from atm
+      allocate(F_flds(13, 2))
+      F_flds(1,:) = (/'Faxa_taux ', 'Foxx_taux'/)
+      F_flds(2,:) = (/'Faxa_tauy ', 'Foxx_tauy'/)
+      F_flds(3,:) = (/'Foxx_sen', 'Foxx_sen'/)
+      F_flds(4,:) = (/'Foxx_evap', 'Foxx_evap'/)
+      F_flds(5,:) = (/'Foxx_lwnet', 'Foxx_lwnet'/)
+      F_flds(6,:) = (/'Foxx_swnet_vdr', 'Foxx_swnet_vdr'/)
+      F_flds(7,:) = (/'Foxx_swnet_vdf', 'Foxx_swnet_vdf'/)
+      F_flds(8,:) = (/'Foxx_swnet_idr', 'Foxx_swnet_idr'/)
+      F_flds(9,:) = (/'Foxx_swnet_idf', 'Foxx_swnet_idf'/)
+      F_flds(10,:) = (/'Faxa_rainc', 'Faxa_rain'/)
+      F_flds(11,:) = (/'Faxa_snowc', 'Faxa_snow'/)
+      F_flds(12,:) = (/'Foxx_rofl', 'Foxx_rofl'/)  ! mean runoff rate (liquid)
+      F_flds(13,:) = (/'Foxx_rofi', 'Foxx_rofi'/)  ! mean runnof rate (frozen)
+
+      do n = 1,size(F_flds,1)
+         fldname1 = trim(F_flds(n,1))
+         fldname2 = trim(F_flds(n,2))
+         call addfld(fldListFr(compatm)%flds, trim(fldname1))
+         call addfld(fldListTo(compocn)%flds, trim(fldname2))
+      end do
+      deallocate(F_flds)
+
+      call addfld(fldListFr(compatm)%flds, 'Faxa_rainc')
+      call addfld(fldListFr(compatm)%flds, 'Faxa_snowc')
+
+      ! from ice
+      allocate(F_flds(6, 2))
+      F_flds(1,:) = (/'Fioi_salt', 'Fioi_salt'/)
+      F_flds(2,:) = (/'Si_ifrac', 'Si_ifrac'/) ! ice_fraction
+      F_flds(3,:) = (/'Fioi_meltw', 'Fioi_meltw'/)
+      F_flds(4,:) = (/'Fioi_melth', 'Fioi_melth'/) ! heat flux sea-ice to ocean
+      F_flds(5,:) = (/'Fioi_taux', 'Foxx_taux'/)
+      F_flds(6,:) = (/'Fioi_tauy', 'Foxx_tauy'/) ! heat flux sea-ice to ocean
+      do n = 1,size(F_flds,1)
+         fldname1 = trim(F_flds(n,1))
+         fldname2 = trim(F_flds(n,2))
+         call addfld(fldListFr(compice)%flds, trim(fldname1))
+         call addfld(fldListTo(compocn)%flds, trim(fldname2))
+      end do
+      deallocate(F_flds)
+
+      !=====================================================================
+      ! FIELDS TO ICE (compice)
+      !=====================================================================
+
+      ! ---------------------------------------------------------------------
+      ! to ice: state fields
+      ! ---------------------------------------------------------------------
+
+      ! from atm
+      allocate(S_flds(2))
+      S_flds = (/'Sa_z', &
+                  'Sa_u', &
+                  'Sa_v', &
+                  'Sa_shum', &
+                  'Sa_tbot', &
+                  'Sa_pbot', &
+                  'Sa_dens', &
+                  'Sa_ptem'/)
+      do n = 1,size(S_flds)
+         fldname = trim(S_flds(n))
+         call addfld(fldListFr(compatm)%flds, trim(fldname))
+         call addfld(fldListTo(compice)%flds, trim(fldname))
+      end do
+      deallocate(S_flds)
+
+      ! from ocn
+      allocate(S_flds(7))
+      S_flds = (/'So_dhdx', & 
+                 'So_dhdy', &
+                 'So_t', & 
+                 'So_s', & 
+                 'So_u', & 
+                 'So_v', & 
+                 'Fioo_q' /) 
+      do n = 1,size(S_flds)
+         fldname = trim(S_flds(n))
+         call addfld(fldListFr(compocn)%flds, trim(fldname))
+         call addfld(fldListTo(compice)%flds, trim(fldname))
+      end do
+      deallocate(S_flds)
+
+      ! ---------------------------------------------------------------------
+      ! to ice: flux fields
+      ! ---------------------------------------------------------------------
+      allocate(F_flds(7, 2))
+      F_flds(1,:) = (/'Faxa_swvdr ', 'Faxa_swvdr '/)
+      F_flds(2,:) = (/'Faxa_swndr ', 'Faxa_swndr '/)
+      F_flds(3,:) = (/'Faxa_swvdf', 'Faxa_swvdf'/)
+      F_flds(4,:) = (/'Faxa_swndf', 'Faxa_swndf'/)
+      F_flds(5,:) = (/'Faxa_lwdn', 'Faxa_lwdn'/)
+      F_flds(6,:) = (/'Faxa_rainl', 'Faxa_rain'/)
+      F_flds(7,:) = (/'Faxa_snowl', 'Faxa_snow'/)
+      do n = 1,size(F_flds,1)
+         fldname1 = trim(F_flds(n,1))
+         fldname2 = trim(F_flds(n,2))
+         call addfld(fldListFr(compatm)%flds, trim(fldname1))
+         call addfld(fldListTo(compice)%flds, trim(fldname2))
+      end do
+      deallocate(F_flds)
+
+      call addfld(fldListFr(compatm)%flds, 'Faxa_rainc')
+      call addfld(fldListFr(compatm)%flds, 'Faxa_snowc')
+      
+      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
+
+    end subroutine esmFldsExchange_access_advt
+
+    !-----------------------------------------------------------------------------
+
+    subroutine esmFldsExchange_access_fchk(gcomp, phase, rc)
+
+      use med_methods_mod       , only : fldchk => med_methods_FB_FldChk
+      use med_internalstate_mod , only : InternalState
+
+      ! input/output parameters:
+      type(ESMF_GridComp)              :: gcomp
+      character(len=*) , intent(in)    :: phase
+      integer          , intent(inout) :: rc
+
+      ! local variables:
+      type(InternalState) :: is_local
+      character(len=*) , parameter   :: subname='(esmFldsExchange_access_fchk)'
+      !--------------------------------------
+
+      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
+      rc = ESMF_SUCCESS
+
+      !---------------------------------------
+      ! Get the internal state
+      !---------------------------------------
+      nullify(is_local%wrap)
+      call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
+      if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+      if (fldchk(is_local%wrap%FBImp(compocn,compocn),'So_omask',rc=rc)) then
+         call ESMF_LogWrite(trim(subname)//": Field connected "//"So_omask", &
+            ESMF_LOGMSG_INFO)
+      else
+         call ESMF_LogSetError(ESMF_FAILURE, &
+            msg=trim(subname)//": Field is not connected "//"So_omask", &
+            line=__LINE__, file=__FILE__, rcToReturn=rc)
+         return  ! bail out
+      endif
+
+      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
+
+    end subroutine esmFldsExchange_access_fchk
+
+    !-----------------------------------------------------------------------------
+
+    subroutine esmFldsExchange_access_init(gcomp, phase, rc)
+
+      use med_methods_mod       , only : fldchk => med_methods_FB_FldChk
+      use med_internalstate_mod , only : InternalState
+      use med_internalstate_mod , only : mapbilnr, mapconsf, mapconsd, mappatch
+      use med_internalstate_mod , only : mapfcopy, mapnstod, mapnstod_consd
+      use med_internalstate_mod , only : mapfillv_bilnr
+      use med_internalstate_mod , only : mapnstod_consf
+      use esmFlds               , only : med_fldList_type
+      use esmFlds               , only : addmap => med_fldList_AddMap
+      use esmFlds               , only : addmrg => med_fldList_AddMrg
+
+      ! input/output parameters:
+      type(ESMF_GridComp)              :: gcomp
+      character(len=*) , intent(in)    :: phase
+      integer          , intent(inout) :: rc
+
+      ! local variables:
+      type(InternalState) :: is_local
+      integer             :: num, i, n
+      integer             :: n1, n2, n3, n4
+      character(len=CL)   :: cvalue
+      character(len=CS)   :: name, fldname
+      character(len=CS)   :: fldname1, fldname2
+      character(len=CS), allocatable :: flds(:)
+      character(len=CS), allocatable :: S_flds(:)
+      character(len=CS), allocatable :: F_flds(:,:)
+      character(len=CS), allocatable :: suffix(:)
+      character(len=*) , parameter   :: subname='(esmFldsExchange_access_init)'
+      !--------------------------------------
+
+      call ESMF_LogWrite(trim(subname)//": called", ESMF_LOGMSG_INFO)
+      rc = ESMF_SUCCESS
+
+      !---------------------------------------
+      ! Get the internal state
+      !---------------------------------------
+      nullify(is_local%wrap)
+      call ESMF_GridCompGetInternalState(gcomp, is_local, rc)
+      if (chkerr(rc,__LINE__,u_FILE_u)) return
+
+      !=====================================================================
+      ! FIELDS TO ATMOSPHERE
+      !=====================================================================
+
+      ! ---------------------------------------------------------------------
+      ! to atm: sea surface temperature
+      ! ---------------------------------------------------------------------
+      call addmap(fldListFr(compocn)%flds, 'So_t', compatm, mapconsf, 'ofrac', 'unset')
+      call addmrg(fldListTo(compatm)%flds, 'So_t', mrg_from=compocn, mrg_fld='So_t', mrg_type='copy')
+
+      call addmap(fldListFr(compice)%flds, 'Si_t', compatm, mapconsf, 'ifrac', 'unset')
+      call addmrg(fldListTo(compatm)%flds, 'Si_t', mrg_from=compice, mrg_fld='Si_t', mrg_type='copy')
+
+      !=====================================================================
+      ! FIELDS TO OCEAN (compocn)
+      !=====================================================================
+
+      ! ---------------------------------------------------------------------
+      ! to ocn: state fields
+      ! ---------------------------------------------------------------------
+      allocate(S_flds(2))
+      S_flds = (/'Sa_pslv', & ! inst_zonal_wind_height10m
+                  'So_duu10n' /) ! inst_temp_height_surface
+      do n = 1,size(S_flds)
+         fldname = trim(S_flds(n))
+         if (fldchk(is_local%wrap%FBExp(compocn), trim(fldname), rc=rc) .and. &
+             fldchk(is_local%wrap%FBImp(compatm, compatm), trim(fldname), rc=rc) &
+            ) then
+
+            call addmap(fldListFr(compatm)%flds, trim(fldname), compocn, mapbilnr, 'one', 'unset')
+            call addmrg(fldListTo(compocn)%flds, trim(fldname), mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy')
+
+         end if
+      end do
+      deallocate(S_flds)
+
+      ! ---------------------------------------------------------------------
+      ! to ocn: flux fields
+      ! ---------------------------------------------------------------------
+
+      ! from atm
+      allocate(F_flds(11, 2))
+      F_flds(1,:) = (/'Foxx_sen', 'Foxx_sen'/)
+      F_flds(2,:) = (/'Foxx_evap', 'Foxx_evap'/)
+      F_flds(3,:) = (/'Foxx_lwnet', 'Foxx_lwnet'/)
+      F_flds(4,:) = (/'Foxx_swnet_vdr', 'Foxx_swnet_vdr'/)
+      F_flds(5,:) = (/'Foxx_swnet_vdf', 'Foxx_swnet_vdf'/)
+      F_flds(6,:) = (/'Foxx_swnet_idr', 'Foxx_swnet_idr'/)
+      F_flds(7,:) = (/'Foxx_swnet_idf', 'Foxx_swnet_idf'/)
+      F_flds(8,:) = (/'Foxx_rofl', 'Foxx_rofl'/)  ! mean runoff rate (liquid)
+      F_flds(9,:) = (/'Foxx_rofi', 'Foxx_rofi'/)  ! mean runnof rate (frozen)
+
+      do n = 1,size(F_flds,1)
+         fldname1 = trim(F_flds(n,1))
+         fldname2 = trim(F_flds(n,2))
+         if (fldchk(is_local%wrap%FBExp(compocn), trim(fldname2), rc=rc) .and. &
+             fldchk(is_local%wrap%FBImp(compatm, compatm), trim(fldname1), rc=rc) &
+            ) then
+            call addmap(fldListFr(compatm)%flds, trim(fldname1), compocn, mapconsf, 'one', 'unset')
+            call addmrg(fldListTo(compocn)%flds, trim(fldname2), mrg_from=compatm, mrg_fld=trim(fldname1), mrg_type='copy')
+         end if
+      end do
+      deallocate(F_flds)
+
+      ! precip
+      call addmap(fldListFr(compatm)%flds, 'Faxa_rainc', compocn, mapconsf, 'one', 'unset')
+      call addmrg(fldListTo(compocn)%flds, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainc', mrg_type='sum')
+      call addmap(fldListFr(compatm)%flds, 'Faxa_rainl', compocn, mapconsf, 'one', 'unset')
+      call addmrg(fldListTo(compocn)%flds, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainl', mrg_type='sum')
+
+      call addmap(fldListFr(compatm)%flds, 'Faxa_snowc', compocn, mapconsf, 'one', 'unset')
+      call addmrg(fldListTo(compocn)%flds, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowc', mrg_type='sum')
+      call addmap(fldListFr(compatm)%flds, 'Faxa_snowl', compocn, mapconsf, 'one', 'unset')
+      call addmrg(fldListTo(compocn)%flds, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowl', mrg_type='sum')
+
+      ! from ice
+      allocate(F_flds(4, 2))
+      F_flds(1,:) = (/'Fioi_salt', 'Fioi_salt'/)
+      F_flds(2,:) = (/'Si_ifrac', 'Si_ifrac'/) ! ice_fraction
+      F_flds(3,:) = (/'Fioi_meltw', 'Fioi_meltw'/)
+      F_flds(4,:) = (/'Fioi_melth', 'Fioi_melth'/) ! heat flux sea-ice to ocean
+      do n = 1,size(F_flds,1)
+         fldname1 = trim(F_flds(n,1))
+         fldname2 = trim(F_flds(n,2))
+         if (fldchk(is_local%wrap%FBExp(compocn), trim(fldname2), rc=rc) .and. &
+             fldchk(is_local%wrap%FBImp(compice, compice), trim(fldname1),rc=rc) &
+            ) then
+            call addmap(fldListFr(compice)%flds, trim(fldname1), compocn, mapfcopy, 'unset', 'unset')
+            call addmrg(fldListTo(compocn)%flds, trim(fldname2), mrg_from=compice, mrg_fld=trim(fldname1), mrg_type='copy')
+         end if
+      end do
+      deallocate(F_flds)
+
+      ! momentum transfer
+      call addmap(fldListFr(compice)%flds, 'Fioi_taux', compocn, mapfcopy, 'unset', 'unset')
+      call addmrg(fldListTo(compocn)%flds, 'Foxx_taux', mrg_from=compice, mrg_fld='Fioi_taux', mrg_type='merge', mrg_fracname='ifrac')
+      call addmap(fldListFr(compatm)%flds, 'Faxa_taux', compocn, mapconsf, 'one', 'unset')
+      call addmrg(fldListTo(compocn)%flds, 'Foxx_taux', mrg_from=compatm, mrg_fld='Faxa_taux', mrg_type='merge', mrg_fracname='ofrac')
+
+      call addmap(fldListFr(compice)%flds, 'Fioi_tauy', compocn, mapfcopy, 'unset', 'unset')
+      call addmrg(fldListTo(compocn)%flds, 'Foxx_tauy', mrg_from=compice, mrg_fld='Fioi_tauy', mrg_type='merge', mrg_fracname='ifrac')
+      call addmap(fldListFr(compatm)%flds, 'Faxa_tauy', compocn, mapconsf, 'one', 'unset')
+      call addmrg(fldListTo(compocn)%flds, 'Foxx_tauy', mrg_from=compatm, mrg_fld='Faxa_tauy', mrg_type='merge', mrg_fracname='ofrac')
+
+      !=====================================================================
+      ! FIELDS TO ICE (compice)
+      !=====================================================================
+
+      ! ---------------------------------------------------------------------
+      ! to ice: state fields
+      ! ---------------------------------------------------------------------
+
+      ! from atm
+      allocate(S_flds(8))
+      S_flds = (/'Sa_z', & ! inst_zonal_wind_height10m
+                  'Sa_u', & ! inst_merid_wind_height10m
+                  'Sa_v ', & ! inst_temp_height2m
+                  'Sa_shum ', & ! inst_spec_humid_height2m
+                  'Sa_tbot', & ! Sa_pslv
+                  'Sa_pbot', &
+                  'Sa_dens', &
+                  'Sa_ptem' /) ! inst_temp_height_surface
+
+      do n = 1,size(S_flds)
+         fldname = trim(S_flds(n))
+         if (fldchk(is_local%wrap%FBExp(compice), trim(fldname),rc=rc) .and. &
+               fldchk(is_local%wrap%FBImp(compatm, compatm), trim(fldname),rc=rc) &
+            ) then
+
+            call addmap(fldListFr(compatm)%flds, trim(fldname), compice, mapbilnr, 'one', 'unset')
+            call addmrg(fldListTo(compice)%flds, trim(fldname), mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy')
+
+         end if
+      end do
+      deallocate(S_flds)
+
+      ! from ocn
+      allocate(S_flds(6))
+      S_flds = (/'So_dhdx', & ! inst_zonal_wind_height10m
+                 'So_dhdy', & ! inst_merid_wind_height10m
+                 'So_t ', & ! inst_temp_height2m
+                 'So_s ', & ! inst_spec_humid_height2m
+                 'So_u', & ! Sa_pslv
+                 'So_v', & ! Sa_pslv
+                 'Fioo_q' /) ! inst_temp_height_surface
+      do n = 1,size(S_flds)
+         fldname = trim(S_flds(n))
+         if (fldchk(is_local%wrap%FBExp(compice),trim(fldname),rc=rc) .and. &
+             fldchk(is_local%wrap%FBImp(compocn, compocn), trim(fldname),rc=rc) &
+            ) then
+
+            call addmap(fldListFr(compocn)%flds, trim(fldname), compice, mapfcopy, 'unset', 'unset')
+            call addmrg(fldListTo(compice)%flds, trim(fldname), mrg_from=compocn, mrg_fld=trim(fldname), mrg_type='copy')
+
+         end if
+      end do
+      deallocate(S_flds)
+
+      ! ---------------------------------------------------------------------
+      ! to ice: flux fields
+      ! ---------------------------------------------------------------------
+
+      ! from atm
+      allocate(F_flds(5, 2))
+      F_flds(1,:) = (/'Faxa_swvdr ', 'Faxa_swvdr '/)
+      F_flds(2,:) = (/'Faxa_swndr ', 'Faxa_swndr '/)
+      F_flds(3,:) = (/'Faxa_swvdf', 'Faxa_swvdf'/)
+      F_flds(4,:) = (/'Faxa_swndf', 'Faxa_swndf'/)
+      F_flds(5,:) = (/'Faxa_lwdn', 'Faxa_lwdn'/)
+
+      do n = 1,size(F_flds,1)
+         fldname1 = trim(F_flds(n,1))
+         fldname2 = trim(F_flds(n,2))
+         if (fldchk(is_local%wrap%FBExp(compice), trim(fldname2), rc=rc) .and. &
+             fldchk(is_local%wrap%FBImp(compatm, compatm), trim(fldname1), rc=rc) &
+            ) then
+
+            call addmap(fldListFr(compatm)%flds, trim(fldname1), compice, mapconsf, 'one', 'unset')
+            call addmrg(fldListTo(compice)%flds, trim(fldname2), mrg_from=compatm, mrg_fld=trim(fldname1), mrg_type='copy')
+
+         end if
+      end do
+      deallocate(F_flds)
+
+      ! precip
+      call addmap(fldListFr(compatm)%flds, 'Faxa_rainc', compice, mapconsf, 'one', 'unset')
+      call addmrg(fldListTo(compice)%flds, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainc', mrg_type='sum')
+      call addmap(fldListFr(compatm)%flds, 'Faxa_rainl', compice, mapconsf, 'one', 'unset')
+      call addmrg(fldListTo(compice)%flds, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainl', mrg_type='sum')
+
+      call addmap(fldListFr(compatm)%flds, 'Faxa_snowc', compice, mapconsf, 'one', 'unset')
+      call addmrg(fldListTo(compice)%flds, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowc', mrg_type='sum')
+      call addmap(fldListFr(compatm)%flds, 'Faxa_snowl', compice, mapconsf, 'one', 'unset')
+      call addmrg(fldListTo(compice)%flds, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowl', mrg_type='sum')
+
+      call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
+
+    end subroutine esmFldsExchange_access_init
+
+    !-----------------------------------------------------------------------------
+
+  end module esmFldsExchange_access_mod

--- a/mediator/esmFldsExchange_access_mod.F90
+++ b/mediator/esmFldsExchange_access_mod.F90
@@ -143,7 +143,7 @@ module esmFldsExchange_access_mod
       ! ---------------------------------------------------------------------
       ! to atm: from ice
       ! ---------------------------------------------------------------------
-      allocate(S_flds(8))
+      allocate(S_flds(9))
       S_flds = (/'Si_t', &
                   'ia_aicen', &
                   'ia_snown', &
@@ -151,7 +151,9 @@ module esmFldsExchange_access_mod
                   'ia_itopt', &
                   'ia_itopk', &
                   'ia_pndfn', &
-                  'ia_pndtn'/) ! sea_surface_temperature
+                  'ia_pndtn', &
+                  'sstfrz' &
+               /) ! sea_surface_temperature
       do n = 1,size(S_flds)
         fldname = trim(S_flds(n))
         call addfld_from(compice, trim(fldname))
@@ -232,7 +234,7 @@ module esmFldsExchange_access_mod
       ! ---------------------------------------------------------------------
 
       ! from atm
-      allocate(S_flds(2))
+      allocate(S_flds(10))
       S_flds = (/'Sa_z', &
                   'Sa_u', &
                   'Sa_v', &
@@ -240,7 +242,9 @@ module esmFldsExchange_access_mod
                   'Sa_tbot', &
                   'Sa_pbot', &
                   'Sa_dens', &
-                  'Sa_ptem'/)
+                  'Sa_ptem', &
+                  'um_icesth', &
+                  'um_icenth' /)
       do n = 1,size(S_flds)
          fldname = trim(S_flds(n))
          call addfld_from(compatm, trim(fldname))
@@ -394,6 +398,9 @@ module esmFldsExchange_access_mod
 
       call addmap_from(compice, 'Si_t', compatm, mapconsd, 'ifrac', 'unset')
       call addmrg_to(compatm, 'Si_t', mrg_from=compice, mrg_fld='Si_t', mrg_type='copy')
+
+      call addmap_from(compice, 'sstfrz', compatm, mapconsf, 'none', 'unset')
+      call addmrg_to(compatm, 'sstfrz', mrg_from=compice, mrg_fld='sstfrz', mrg_type='copy')
       
       allocate(S_flds(7))
       S_flds = (/'ia_aicen', &
@@ -514,15 +521,17 @@ module esmFldsExchange_access_mod
       ! ---------------------------------------------------------------------
 
       ! from atm
-      allocate(S_flds(8))
-      S_flds = (/'Sa_z', & ! inst_zonal_wind_height10m
-                  'Sa_u', & ! inst_merid_wind_height10m
-                  'Sa_v ', & ! inst_temp_height2m
-                  'Sa_shum ', & ! inst_spec_humid_height2m
-                  'Sa_tbot', & ! Sa_pslv
+      allocate(S_flds(10))
+      S_flds = (/'Sa_z', &
+                  'Sa_u', &
+                  'Sa_v', &
+                  'Sa_shum', &
+                  'Sa_tbot', &
                   'Sa_pbot', &
                   'Sa_dens', &
-                  'Sa_ptem' /) ! inst_temp_height_surface
+                  'Sa_ptem', &
+                  'um_icesth', &
+                  'um_icenth' /)
 
       do n = 1,size(S_flds)
          fldname = trim(S_flds(n))

--- a/mediator/esmFldsExchange_access_mod.F90
+++ b/mediator/esmFldsExchange_access_mod.F90
@@ -151,8 +151,7 @@ module esmFldsExchange_access_mod
                   'ia_itopt', &
                   'ia_itopk', &
                   'ia_pndfn', &
-                  'ia_pndtn', &
-               /) ! sea_surface_temperature
+                  'ia_pndtn'/) ! sea_surface_temperature
       do n = 1,size(S_flds)
         fldname = trim(S_flds(n))
         call addfld(fldListFr(compice)%flds, trim(fldname))
@@ -390,8 +389,7 @@ module esmFldsExchange_access_mod
                   'ia_itopt', &
                   'ia_itopk', &
                   'ia_pndfn', &
-                  'ia_pndtn', &
-               /) ! sea_surface_temperature
+                  'ia_pndtn'/) ! sea_surface_temperature
       do n = 1,size(S_flds)
         fldname = trim(S_flds(n))
         call addmap(fldListFr(compice)%flds, trim(fldname), compatm, mapconsf, 'ifrac', 'unset')

--- a/mediator/esmFldsExchange_access_mod.F90
+++ b/mediator/esmFldsExchange_access_mod.F90
@@ -489,7 +489,7 @@ module esmFldsExchange_access_mod
              fldchk(is_local%wrap%FBImp(compice, compice), trim(fldname1),rc=rc) &
             ) then
             call addmap_from(compice, trim(fldname1), compocn, mapfcopy, 'unset', 'unset')
-            call addmrg_to(compocn, trim(fldname2), mrg_from=compice, mrg_fld=trim(fldname1), mrg_type='copy_with_weights', mrg_fracname='ifrac')
+            call addmrg_to(compocn, trim(fldname2), mrg_from=compice, mrg_fld=trim(fldname1), mrg_type='copy')
          end if
       end do
       deallocate(F_flds)

--- a/mediator/esmFldsExchange_access_mod.F90
+++ b/mediator/esmFldsExchange_access_mod.F90
@@ -465,14 +465,14 @@ module esmFldsExchange_access_mod
 
       ! precip
       call addmap_from(compatm, 'Faxa_rainc', compocn, mapconsf, 'one', 'unset') ! TODO: weight by ocean fraction
-      call addmrg_to(compocn, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainc', mrg_type='sum_with_weights', mrg_fracname='ofrac')
       call addmap_from(compatm, 'Faxa_rainl', compocn, mapconsf, 'one', 'unset')
-      call addmrg_to(compocn, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainl', mrg_type='sum_with_weights', mrg_fracname='ofrac')
-
+      call addmrg_to(compocn, 'Faxa_rain' , mrg_from=compatm, mrg_fld='Faxa_rainc:Faxa_rainl', &
+               mrg_type='sum_with_weights', mrg_fracname='ofrac')
+      
       call addmap_from(compatm, 'Faxa_snowc', compocn, mapconsf, 'one', 'unset')
-      call addmrg_to(compocn, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowc', mrg_type='sum_with_weights', mrg_fracname='ofrac')
       call addmap_from(compatm, 'Faxa_snowl', compocn, mapconsf, 'one', 'unset')
-      call addmrg_to(compocn, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowl', mrg_type='sum_with_weights', mrg_fracname='ofrac')
+      call addmrg_to(compocn, 'Faxa_snow' , mrg_from=compatm, mrg_fld='Faxa_snowc:Faxa_snowl', &
+               mrg_type='sum_with_weights', mrg_fracname='ofrac')
       
       ! from ice
       call addmap_from(compice, 'Si_ifrac', compocn, mapfcopy, 'unset', 'unset')
@@ -594,14 +594,14 @@ module esmFldsExchange_access_mod
 
       ! precip
       call addmap_from(compatm, 'Faxa_rainc', compice, mapconsf, 'one', 'unset')
-      call addmrg_to(compice, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainc', mrg_type='sum')
       call addmap_from(compatm, 'Faxa_rainl', compice, mapconsf, 'one', 'unset')
-      call addmrg_to(compice, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainl', mrg_type='sum')
-
+      call addmrg_to(compice, 'Faxa_rain' , mrg_from=compatm, mrg_fld='Faxa_rainc:Faxa_rainl', &
+               mrg_type='sum')
+      
       call addmap_from(compatm, 'Faxa_snowc', compice, mapconsf, 'one', 'unset')
-      call addmrg_to(compice, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowc', mrg_type='sum')
       call addmap_from(compatm, 'Faxa_snowl', compice, mapconsf, 'one', 'unset')
-      call addmrg_to(compice, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowl', mrg_type='sum')
+      call addmrg_to(compice, 'Faxa_snow' , mrg_from=compatm, mrg_fld='Faxa_snowc:Faxa_snowl', &
+               mrg_type='sum')
 
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
 

--- a/mediator/esmFldsExchange_access_mod.F90
+++ b/mediator/esmFldsExchange_access_mod.F90
@@ -142,8 +142,22 @@ module esmFldsExchange_access_mod
       ! ---------------------------------------------------------------------
       ! to atm: from ice
       ! ---------------------------------------------------------------------
-      call addfld(fldListFr(compice)%flds, 'Si_t')
-      call addfld(fldListTo(compatm)%flds, 'Si_t')
+      allocate(S_flds(8))
+      S_flds = (/'Si_t', &
+                  'ia_aicen', &
+                  'ia_snown', &
+                  'ia_thikn', &
+                  'ia_itopt', &
+                  'ia_itopk', &
+                  'ia_pndfn', &
+                  'ia_pndtn', &
+               /) ! sea_surface_temperature
+      do n = 1,size(S_flds)
+        fldname = trim(S_flds(n))
+        call addfld(fldListFr(compice)%flds, trim(fldname))
+        call addfld(fldListTo(compatm)%flds, trim(fldname))
+      end do
+      deallocate(S_flds)
 
       !=====================================================================
       ! FIELDS TO OCEAN (compocn)
@@ -370,8 +384,24 @@ module esmFldsExchange_access_mod
       call addmap(fldListFr(compocn)%flds, 'So_t', compatm, mapconsf, 'ofrac', 'unset')
       call addmrg(fldListTo(compatm)%flds, 'So_t', mrg_from=compocn, mrg_fld='So_t', mrg_type='copy')
 
-      call addmap(fldListFr(compice)%flds, 'Si_t', compatm, mapconsf, 'ifrac', 'unset')
-      call addmrg(fldListTo(compatm)%flds, 'Si_t', mrg_from=compice, mrg_fld='Si_t', mrg_type='copy')
+      allocate(S_flds(8))
+      S_flds = (/'Si_t', &
+                  'ia_aicen', &
+                  'ia_snown', &
+                  'ia_thikn', &
+                  'ia_itopt', &
+                  'ia_itopk', &
+                  'ia_pndfn', &
+                  'ia_pndtn', &
+               /) ! sea_surface_temperature
+      do n = 1,size(S_flds)
+        fldname = trim(S_flds(n))
+        call addmap(fldListFr(compice)%flds, trim(fldname), compatm, mapconsf, 'ifrac', 'unset')
+        call addmrg(fldListTo(compatm)%flds, trim(fldname), mrg_from=compice, mrg_fld=trim(fldname), mrg_type='copy')
+      end do
+      deallocate(S_flds)
+      ! call addmap(fldListFr(compice)%flds, 'Si_t', compatm, mapconsf, 'ifrac', 'unset')
+      ! call addmrg(fldListTo(compatm)%flds, 'Si_t', mrg_from=compice, mrg_fld='Si_t', mrg_type='copy')
 
       !=====================================================================
       ! FIELDS TO OCEAN (compocn)

--- a/mediator/esmFldsExchange_access_mod.F90
+++ b/mediator/esmFldsExchange_access_mod.F90
@@ -10,8 +10,11 @@ module esmFldsExchange_access_mod
     use med_internalstate_mod , only : compmed, compatm, compocn, compwav, compice
     use med_internalstate_mod , only : ncomps
     use med_internalstate_mod , only : coupling_mode
-    use esmflds               , only : fldListTo
-    use esmflds               , only : fldListFr
+    use esmFlds               , only : med_fldList_type
+    use esmFlds               , only : addfld_to => med_fldList_addfld_to
+    use esmFlds               , only : addmrg_to => med_fldList_addmrg_to
+    use esmFlds               , only : addfld_from => med_fldList_addfld_from
+    use esmFlds               , only : addmap_from => med_fldList_addmap_from
 
     !---------------------------------------------------------------------
     ! This is a mediator specific routine that determines ALL possible
@@ -69,8 +72,6 @@ module esmFldsExchange_access_mod
 
     subroutine esmFldsExchange_access_advt(gcomp, phase, rc)
 
-      use esmFlds, only : addfld => med_fldList_AddFld
-
       ! input/output parameters:
       type(ESMF_GridComp)              :: gcomp
       character(len=*) , intent(in)    :: phase
@@ -104,8 +105,8 @@ module esmFldsExchange_access_mod
             value=cvalue, rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
          do n = 1,ncomps
-            call addfld(fldListFr(n)%flds, trim(cvalue))
-            call addfld(fldListTo(n)%flds, trim(cvalue))
+            call addfld_from(n, trim(cvalue))
+            call addfld_to(n, trim(cvalue))
          end do
       end if
 
@@ -117,15 +118,15 @@ module esmFldsExchange_access_mod
       !----------------------------------------------------------
       ! to med: masks from components
       !----------------------------------------------------------
-      call addfld(fldListFr(compocn)%flds, 'So_omask')
-      call addfld(fldListFr(compice)%flds, 'Si_imask')
+      call addfld_from(compocn, 'So_omask')
+      call addfld_from(compice, 'Si_imask')
 
       !=====================================================================
       ! FIELDS TO ATMOSPHERE
       !=====================================================================
 
-      call addfld(fldListTo(compatm)%flds, 'So_ofrac')
-      call addfld(fldListTo(compatm)%flds, 'Si_ifrac')
+      call addfld_to(compatm, 'So_ofrac')
+      call addfld_to(compatm, 'Si_ifrac')
 
       ! ---------------------------------------------------------------------
       ! to atm: from ocn
@@ -134,16 +135,16 @@ module esmFldsExchange_access_mod
       S_flds = (/'So_t'/) ! sea_surface_temperature
       do n = 1,size(S_flds)
         fldname = trim(S_flds(n))
-        call addfld(fldListFr(compocn)%flds, trim(fldname))
-        call addfld(fldListTo(compatm)%flds, trim(fldname))
+        call addfld_from(compocn, trim(fldname))
+        call addfld_to(compatm, trim(fldname))
       end do
       deallocate(S_flds)
 
       ! ---------------------------------------------------------------------
       ! to atm: from ice
       ! ---------------------------------------------------------------------
-      call addfld(fldListFr(compice)%flds, 'Si_t')
-      call addfld(fldListTo(compatm)%flds, 'Si_t')
+      call addfld_from(compice, 'Si_t')
+      call addfld_to(compatm, 'Si_t')
 
       !=====================================================================
       ! FIELDS TO OCEAN (compocn)
@@ -157,8 +158,8 @@ module esmFldsExchange_access_mod
                   'So_duu10n' /) ! inst_temp_height_surface
       do n = 1,size(S_flds)
          fldname = trim(S_flds(n))
-         call addfld(fldListFr(compatm)%flds, trim(fldname))
-         call addfld(fldListTo(compocn)%flds, trim(fldname))
+         call addfld_from(compatm, trim(fldname))
+         call addfld_to(compocn, trim(fldname))
       end do
       deallocate(S_flds)
 
@@ -185,13 +186,13 @@ module esmFldsExchange_access_mod
       do n = 1,size(F_flds,1)
          fldname1 = trim(F_flds(n,1))
          fldname2 = trim(F_flds(n,2))
-         call addfld(fldListFr(compatm)%flds, trim(fldname1))
-         call addfld(fldListTo(compocn)%flds, trim(fldname2))
+         call addfld_from(compatm, trim(fldname1))
+         call addfld_to(compocn, trim(fldname2))
       end do
       deallocate(F_flds)
 
-      call addfld(fldListFr(compatm)%flds, 'Faxa_rainc')
-      call addfld(fldListFr(compatm)%flds, 'Faxa_snowc')
+      call addfld_from(compatm, 'Faxa_rainc')
+      call addfld_from(compatm, 'Faxa_snowc')
 
       ! from ice
       allocate(F_flds(6, 2))
@@ -204,8 +205,8 @@ module esmFldsExchange_access_mod
       do n = 1,size(F_flds,1)
          fldname1 = trim(F_flds(n,1))
          fldname2 = trim(F_flds(n,2))
-         call addfld(fldListFr(compice)%flds, trim(fldname1))
-         call addfld(fldListTo(compocn)%flds, trim(fldname2))
+         call addfld_from(compice, trim(fldname1))
+         call addfld_to(compocn, trim(fldname2))
       end do
       deallocate(F_flds)
 
@@ -229,8 +230,8 @@ module esmFldsExchange_access_mod
                   'Sa_ptem'/)
       do n = 1,size(S_flds)
          fldname = trim(S_flds(n))
-         call addfld(fldListFr(compatm)%flds, trim(fldname))
-         call addfld(fldListTo(compice)%flds, trim(fldname))
+         call addfld_from(compatm, trim(fldname))
+         call addfld_to(compice, trim(fldname))
       end do
       deallocate(S_flds)
 
@@ -245,8 +246,8 @@ module esmFldsExchange_access_mod
                  'Fioo_q' /) 
       do n = 1,size(S_flds)
          fldname = trim(S_flds(n))
-         call addfld(fldListFr(compocn)%flds, trim(fldname))
-         call addfld(fldListTo(compice)%flds, trim(fldname))
+         call addfld_from(compocn, trim(fldname))
+         call addfld_to(compice, trim(fldname))
       end do
       deallocate(S_flds)
 
@@ -264,13 +265,13 @@ module esmFldsExchange_access_mod
       do n = 1,size(F_flds,1)
          fldname1 = trim(F_flds(n,1))
          fldname2 = trim(F_flds(n,2))
-         call addfld(fldListFr(compatm)%flds, trim(fldname1))
-         call addfld(fldListTo(compice)%flds, trim(fldname2))
+         call addfld_from(compatm, trim(fldname1))
+         call addfld_to(compice, trim(fldname2))
       end do
       deallocate(F_flds)
 
-      call addfld(fldListFr(compatm)%flds, 'Faxa_rainc')
-      call addfld(fldListFr(compatm)%flds, 'Faxa_snowc')
+      call addfld_from(compatm, 'Faxa_rainc')
+      call addfld_from(compatm, 'Faxa_snowc')
       
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
 
@@ -327,9 +328,6 @@ module esmFldsExchange_access_mod
       use med_internalstate_mod , only : mapfcopy, mapnstod, mapnstod_consd
       use med_internalstate_mod , only : mapfillv_bilnr
       use med_internalstate_mod , only : mapnstod_consf
-      use esmFlds               , only : med_fldList_type
-      use esmFlds               , only : addmap => med_fldList_AddMap
-      use esmFlds               , only : addmrg => med_fldList_AddMrg
 
       ! input/output parameters:
       type(ESMF_GridComp)              :: gcomp
@@ -367,11 +365,11 @@ module esmFldsExchange_access_mod
       ! ---------------------------------------------------------------------
       ! to atm: sea surface temperature
       ! ---------------------------------------------------------------------
-      call addmap(fldListFr(compocn)%flds, 'So_t', compatm, mapconsf, 'ofrac', 'unset')
-      call addmrg(fldListTo(compatm)%flds, 'So_t', mrg_from=compocn, mrg_fld='So_t', mrg_type='copy')
+      call addmap_from(compocn, 'So_t', compatm, mapconsf, 'ofrac', 'unset')
+      call addmrg_to(compatm, 'So_t', mrg_from=compocn, mrg_fld='So_t', mrg_type='copy')
 
-      call addmap(fldListFr(compice)%flds, 'Si_t', compatm, mapconsf, 'ifrac', 'unset')
-      call addmrg(fldListTo(compatm)%flds, 'Si_t', mrg_from=compice, mrg_fld='Si_t', mrg_type='copy')
+      call addmap_from(compice, 'Si_t', compatm, mapconsf, 'ifrac', 'unset')
+      call addmrg_to(compatm, 'Si_t', mrg_from=compice, mrg_fld='Si_t', mrg_type='copy')
 
       !=====================================================================
       ! FIELDS TO OCEAN (compocn)
@@ -389,8 +387,8 @@ module esmFldsExchange_access_mod
              fldchk(is_local%wrap%FBImp(compatm, compatm), trim(fldname), rc=rc) &
             ) then
 
-            call addmap(fldListFr(compatm)%flds, trim(fldname), compocn, mapbilnr, 'one', 'unset')
-            call addmrg(fldListTo(compocn)%flds, trim(fldname), mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy')
+            call addmap_from(compatm, trim(fldname), compocn, mapbilnr, 'one', 'unset')
+            call addmrg_to(compocn, trim(fldname), mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy')
 
          end if
       end do
@@ -418,22 +416,22 @@ module esmFldsExchange_access_mod
          if (fldchk(is_local%wrap%FBExp(compocn), trim(fldname2), rc=rc) .and. &
              fldchk(is_local%wrap%FBImp(compatm, compatm), trim(fldname1), rc=rc) &
             ) then
-            call addmap(fldListFr(compatm)%flds, trim(fldname1), compocn, mapconsf, 'one', 'unset')
-            call addmrg(fldListTo(compocn)%flds, trim(fldname2), mrg_from=compatm, mrg_fld=trim(fldname1), mrg_type='copy')
+            call addmap_from(compatm, trim(fldname1), compocn, mapconsf, 'one', 'unset')
+            call addmrg_to(compocn, trim(fldname2), mrg_from=compatm, mrg_fld=trim(fldname1), mrg_type='copy')
          end if
       end do
       deallocate(F_flds)
 
       ! precip
-      call addmap(fldListFr(compatm)%flds, 'Faxa_rainc', compocn, mapconsf, 'one', 'unset')
-      call addmrg(fldListTo(compocn)%flds, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainc', mrg_type='sum')
-      call addmap(fldListFr(compatm)%flds, 'Faxa_rainl', compocn, mapconsf, 'one', 'unset')
-      call addmrg(fldListTo(compocn)%flds, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainl', mrg_type='sum')
+      call addmap_from(compatm, 'Faxa_rainc', compocn, mapconsf, 'one', 'unset')
+      call addmrg_to(compocn, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainc', mrg_type='sum')
+      call addmap_from(compatm, 'Faxa_rainl', compocn, mapconsf, 'one', 'unset')
+      call addmrg_to(compocn, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainl', mrg_type='sum')
 
-      call addmap(fldListFr(compatm)%flds, 'Faxa_snowc', compocn, mapconsf, 'one', 'unset')
-      call addmrg(fldListTo(compocn)%flds, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowc', mrg_type='sum')
-      call addmap(fldListFr(compatm)%flds, 'Faxa_snowl', compocn, mapconsf, 'one', 'unset')
-      call addmrg(fldListTo(compocn)%flds, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowl', mrg_type='sum')
+      call addmap_from(compatm, 'Faxa_snowc', compocn, mapconsf, 'one', 'unset')
+      call addmrg_to(compocn, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowc', mrg_type='sum')
+      call addmap_from(compatm, 'Faxa_snowl', compocn, mapconsf, 'one', 'unset')
+      call addmrg_to(compocn, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowl', mrg_type='sum')
 
       ! from ice
       allocate(F_flds(4, 2))
@@ -447,22 +445,22 @@ module esmFldsExchange_access_mod
          if (fldchk(is_local%wrap%FBExp(compocn), trim(fldname2), rc=rc) .and. &
              fldchk(is_local%wrap%FBImp(compice, compice), trim(fldname1),rc=rc) &
             ) then
-            call addmap(fldListFr(compice)%flds, trim(fldname1), compocn, mapfcopy, 'unset', 'unset')
-            call addmrg(fldListTo(compocn)%flds, trim(fldname2), mrg_from=compice, mrg_fld=trim(fldname1), mrg_type='copy')
+            call addmap_from(compice, trim(fldname1), compocn, mapfcopy, 'unset', 'unset')
+            call addmrg_to(compocn, trim(fldname2), mrg_from=compice, mrg_fld=trim(fldname1), mrg_type='copy')
          end if
       end do
       deallocate(F_flds)
 
       ! momentum transfer
-      call addmap(fldListFr(compice)%flds, 'Fioi_taux', compocn, mapfcopy, 'unset', 'unset')
-      call addmrg(fldListTo(compocn)%flds, 'Foxx_taux', mrg_from=compice, mrg_fld='Fioi_taux', mrg_type='merge', mrg_fracname='ifrac')
-      call addmap(fldListFr(compatm)%flds, 'Faxa_taux', compocn, mapconsf, 'one', 'unset')
-      call addmrg(fldListTo(compocn)%flds, 'Foxx_taux', mrg_from=compatm, mrg_fld='Faxa_taux', mrg_type='merge', mrg_fracname='ofrac')
+      call addmap_from(compice, 'Fioi_taux', compocn, mapfcopy, 'unset', 'unset')
+      call addmrg_to(compocn, 'Foxx_taux', mrg_from=compice, mrg_fld='Fioi_taux', mrg_type='merge', mrg_fracname='ifrac')
+      call addmap_from(compatm, 'Faxa_taux', compocn, mapconsf, 'one', 'unset')
+      call addmrg_to(compocn, 'Foxx_taux', mrg_from=compatm, mrg_fld='Faxa_taux', mrg_type='merge', mrg_fracname='ofrac')
 
-      call addmap(fldListFr(compice)%flds, 'Fioi_tauy', compocn, mapfcopy, 'unset', 'unset')
-      call addmrg(fldListTo(compocn)%flds, 'Foxx_tauy', mrg_from=compice, mrg_fld='Fioi_tauy', mrg_type='merge', mrg_fracname='ifrac')
-      call addmap(fldListFr(compatm)%flds, 'Faxa_tauy', compocn, mapconsf, 'one', 'unset')
-      call addmrg(fldListTo(compocn)%flds, 'Foxx_tauy', mrg_from=compatm, mrg_fld='Faxa_tauy', mrg_type='merge', mrg_fracname='ofrac')
+      call addmap_from(compice, 'Fioi_tauy', compocn, mapfcopy, 'unset', 'unset')
+      call addmrg_to(compocn, 'Foxx_tauy', mrg_from=compice, mrg_fld='Fioi_tauy', mrg_type='merge', mrg_fracname='ifrac')
+      call addmap_from(compatm, 'Faxa_tauy', compocn, mapconsf, 'one', 'unset')
+      call addmrg_to(compocn, 'Foxx_tauy', mrg_from=compatm, mrg_fld='Faxa_tauy', mrg_type='merge', mrg_fracname='ofrac')
 
       !=====================================================================
       ! FIELDS TO ICE (compice)
@@ -489,8 +487,8 @@ module esmFldsExchange_access_mod
                fldchk(is_local%wrap%FBImp(compatm, compatm), trim(fldname),rc=rc) &
             ) then
 
-            call addmap(fldListFr(compatm)%flds, trim(fldname), compice, mapbilnr, 'one', 'unset')
-            call addmrg(fldListTo(compice)%flds, trim(fldname), mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy')
+            call addmap_from(compatm, trim(fldname), compice, mapbilnr, 'one', 'unset')
+            call addmrg_to(compice, trim(fldname), mrg_from=compatm, mrg_fld=trim(fldname), mrg_type='copy')
 
          end if
       end do
@@ -511,8 +509,8 @@ module esmFldsExchange_access_mod
              fldchk(is_local%wrap%FBImp(compocn, compocn), trim(fldname),rc=rc) &
             ) then
 
-            call addmap(fldListFr(compocn)%flds, trim(fldname), compice, mapfcopy, 'unset', 'unset')
-            call addmrg(fldListTo(compice)%flds, trim(fldname), mrg_from=compocn, mrg_fld=trim(fldname), mrg_type='copy')
+            call addmap_from(compocn, trim(fldname), compice, mapfcopy, 'unset', 'unset')
+            call addmrg_to(compice, trim(fldname), mrg_from=compocn, mrg_fld=trim(fldname), mrg_type='copy')
 
          end if
       end do
@@ -537,23 +535,23 @@ module esmFldsExchange_access_mod
              fldchk(is_local%wrap%FBImp(compatm, compatm), trim(fldname1), rc=rc) &
             ) then
 
-            call addmap(fldListFr(compatm)%flds, trim(fldname1), compice, mapconsf, 'one', 'unset')
-            call addmrg(fldListTo(compice)%flds, trim(fldname2), mrg_from=compatm, mrg_fld=trim(fldname1), mrg_type='copy')
+            call addmap_from(compatm, trim(fldname1), compice, mapconsf, 'one', 'unset')
+            call addmrg_to(compice, trim(fldname2), mrg_from=compatm, mrg_fld=trim(fldname1), mrg_type='copy')
 
          end if
       end do
       deallocate(F_flds)
 
       ! precip
-      call addmap(fldListFr(compatm)%flds, 'Faxa_rainc', compice, mapconsf, 'one', 'unset')
-      call addmrg(fldListTo(compice)%flds, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainc', mrg_type='sum')
-      call addmap(fldListFr(compatm)%flds, 'Faxa_rainl', compice, mapconsf, 'one', 'unset')
-      call addmrg(fldListTo(compice)%flds, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainl', mrg_type='sum')
+      call addmap_from(compatm, 'Faxa_rainc', compice, mapconsf, 'one', 'unset')
+      call addmrg_to(compice, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainc', mrg_type='sum')
+      call addmap_from(compatm, 'Faxa_rainl', compice, mapconsf, 'one', 'unset')
+      call addmrg_to(compice, 'Faxa_rain', mrg_from=compatm, mrg_fld='Faxa_rainl', mrg_type='sum')
 
-      call addmap(fldListFr(compatm)%flds, 'Faxa_snowc', compice, mapconsf, 'one', 'unset')
-      call addmrg(fldListTo(compice)%flds, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowc', mrg_type='sum')
-      call addmap(fldListFr(compatm)%flds, 'Faxa_snowl', compice, mapconsf, 'one', 'unset')
-      call addmrg(fldListTo(compice)%flds, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowl', mrg_type='sum')
+      call addmap_from(compatm, 'Faxa_snowc', compice, mapconsf, 'one', 'unset')
+      call addmrg_to(compice, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowc', mrg_type='sum')
+      call addmap_from(compatm, 'Faxa_snowl', compice, mapconsf, 'one', 'unset')
+      call addmrg_to(compice, 'Faxa_snow', mrg_from=compatm, mrg_fld='Faxa_snowl', mrg_type='sum')
 
       call ESMF_LogWrite(trim(subname)//": done", ESMF_LOGMSG_INFO)
 

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -823,9 +823,9 @@ contains
     else if (trim(coupling_mode(1:4)) == 'hafs') then
        call esmFldsExchange_hafs(gcomp, phase='advertise', rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
-     else if (trim(coupling_mode(1:4)) == 'access') then
-          call esmFldsExchange_access(gcomp, phase='advertise', rc=rc)
-          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+    else if (trim(coupling_mode) == 'access') then
+       call esmFldsExchange_access(gcomp, phase='advertise', rc=rc)
+       if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else
         call ESMF_LogWrite(trim(coupling_mode)//' is not a valid coupling_mode', ESMF_LOGMSG_INFO)
         call ESMF_Finalize(endflag=ESMF_END_ABORT)

--- a/mediator/med.F90
+++ b/mediator/med.F90
@@ -51,6 +51,7 @@ module MED
   use esmFldsExchange_nems_mod , only : esmFldsExchange_nems
   use esmFldsExchange_cesm_mod , only : esmFldsExchange_cesm
   use esmFldsExchange_hafs_mod , only : esmFldsExchange_hafs
+  use esmFldsExchange_access_mod , only : esmFldsExchange_access
   use med_phases_profile_mod   , only : med_phases_profile_finalize
 
   implicit none
@@ -822,6 +823,9 @@ contains
     else if (trim(coupling_mode(1:4)) == 'hafs') then
        call esmFldsExchange_hafs(gcomp, phase='advertise', rc=rc)
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
+     else if (trim(coupling_mode(1:4)) == 'access') then
+          call esmFldsExchange_access(gcomp, phase='advertise', rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else
         call ESMF_LogWrite(trim(coupling_mode)//' is not a valid coupling_mode', ESMF_LOGMSG_INFO)
         call ESMF_Finalize(endflag=ESMF_END_ABORT)
@@ -1808,6 +1812,9 @@ contains
       else if (trim(coupling_mode) == 'hafs') then
          call esmFldsExchange_hafs(gcomp, phase='initialize', rc=rc)
          if (ChkErr(rc,__LINE__,u_FILE_u)) return
+     else if (trim(coupling_mode) == 'access') then
+          call esmFldsExchange_access(gcomp, phase='initialize', rc=rc)
+          if (ChkErr(rc,__LINE__,u_FILE_u)) return
       end if
 
       if (maintask) then

--- a/mediator/med_merge_mod.F90
+++ b/mediator/med_merge_mod.F90
@@ -334,6 +334,8 @@ contains
     real(R8), pointer :: dpf2(:,:)  ! intput pointers to 1d and 2d fields
     real(R8), pointer :: dpw1(:)    ! weight pointer
     character(len=*),parameter :: subname=' (med_merge_mod: med_merge_auto_field)'
+    character(len=CL) :: tmpString
+    integer           :: ungriddedUbound_out1(1)
     !---------------------------------------
 
     rc = ESMF_SUCCESS
@@ -367,6 +369,19 @@ contains
 
     ! Get field pointer to output and input fields
     ! Assume that input and output ungridded upper bounds are the same - this is checked in error check
+
+    ! field_in
+    ! field_out
+
+    call ESMF_FieldGet(field_in, ungriddedUBound=ungriddedUbound_out1, rc=rc)
+    write (tmpString, *) ungriddedUbound_out1(1)
+    call ESMF_LogWrite('Input ungridded ubound: ' // trim(tmpString), ESMF_LogMsg_Info, rc=rc)
+    
+    call ESMF_FieldGet(field_out, ungriddedUBound=ungriddedUbound_out1, rc=rc)
+    write (tmpString, *) ungriddedUbound_out1(1)
+    call ESMF_LogWrite('Output ungridded ubound: ' // trim(tmpString), ESMF_LogMsg_Info, rc=rc)
+    
+
 
     if (ungriddedUBound_out(1) > 0) then
        call ESMF_FieldGet(field_in, farrayPtr=dpf2, rc=rc)

--- a/mediator/med_methods_mod.F90
+++ b/mediator/med_methods_mod.F90
@@ -449,9 +449,11 @@ contains
                 call ESMF_FieldBundleGet(FBflds, fieldName=lfieldnamelist(n), field=lfield, rc=rc)
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
              elseif (present(STflds)) then
-                call med_methods_State_getNameN(STflds, n, lname, rc)
+                ! call med_methods_State_getNameN(STflds, n, lname, rc)
+                ! Code change here
+                lname = trim(lfieldnamelist(n))
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
-                call ESMF_StateGet(STflds, itemName=lname, field=lfield, rc=rc)
+                call ESMF_StateGet(STflds, itemName=lname, field=lfield, rc=rc)                
                 if (chkerr(rc,__LINE__,u_FILE_u)) return
              end if
 

--- a/mediator/med_phases_history_mod.F90
+++ b/mediator/med_phases_history_mod.F90
@@ -1300,7 +1300,7 @@ contains
              call med_io_write(auxcomp%files(nf)%io_file, is_local%wrap%FBimp(compid,compid), &
                   whead(1), wdata(1), nx, ny, nt=auxcomp%files(nf)%nt, &
                   pre=trim(compname(compid))//'Imp', flds=auxcomp%files(nf)%flds, &
-                  use_float=.true., rc=rc)
+                  use_float=.false., rc=rc)
              if (ChkErr(rc,__LINE__,u_FILE_u)) return
 
              ! end definition phase

--- a/mediator/med_phases_prep_atm_mod.F90
+++ b/mediator/med_phases_prep_atm_mod.F90
@@ -147,7 +147,8 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else if (trim(coupling_mode) == 'nems_frac' .or. &
              trim(coupling_mode) == 'nems_orig' .or. &
-             trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
+             trim(coupling_mode) == 'nems_frac_aoflux_sbs' .or. &
+             trim(coupling_mode) == 'access') then
        call med_merge_auto(&
             is_local%wrap%med_coupling_active(:,compatm), &
             is_local%wrap%FBExp(compatm), &

--- a/mediator/med_phases_prep_ocn_mod.F90
+++ b/mediator/med_phases_prep_ocn_mod.F90
@@ -131,7 +131,8 @@ contains
        if (ChkErr(rc,__LINE__,u_FILE_u)) return
     else if (trim(coupling_mode) == 'nems_frac' .or. &
              trim(coupling_mode) == 'nems_orig' .or. &
-             trim(coupling_mode) == 'nems_frac_aoflux_sbs') then
+             trim(coupling_mode) == 'nems_frac_aoflux_sbs' .or. &
+             trim(coupling_mode) == 'access') then
        call med_merge_auto(&
             is_local%wrap%med_coupling_active(:,compocn), &
             is_local%wrap%FBExp(compocn), &


### PR DESCRIPTION
This PR forms part of the work for https://github.com/ACCESS-NRI/dev_coupling/issues/51

It merges our version of CMEPS, based on version 0.14.35, with CMEPS1.0.25, which is the version currently used in OM3.

I'll add separate comments for the choices for the different merge conflicts.
