### PR TITLE
Use total precipitation field rather than convective & resolves separately

### DIFF
--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -613,7 +613,7 @@ contains
              if (chkerr(rc,__LINE__,u_FILE_u)) return
              if (lndAccum2glc_cnt > 0) then
                 ! If accumulation count is greater than 0, do the averaging
-                data2d(:,:) = data2d(:,:) / real(lndAccum2glc_cnt)
+                data2d(:,:) = data2d(:,:) / real(lndAccum2glc_cnt, R8)
              else
                 ! If accumulation count is 0, then simply set the averaged field bundle values from the land
                 ! to the import field bundle values
@@ -631,7 +631,7 @@ contains
              if (chkerr(rc,__LINE__,u_FILE_u)) return
              if (ocnAccum2glc_cnt > 0) then
                 ! If accumulation count is greater than 0, do the averaging
-                data2d(:,:) = data2d(:,:) / real(ocnAccum2glc_cnt)
+                data2d(:,:) = data2d(:,:) / real(ocnAccum2glc_cnt, R8)
              else
                 ! If accumulation count is 0, then simply set the averaged field bundle values from the ocn
                 ! to the import field bundle values

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -924,8 +924,8 @@ contains
                          data_ice_covered_g(n) = dataptr2d(ec-1,n) * 0.5_r8 &
                               + dataptr2d(ec  ,n) * 0.5_r8
                       else
-                         data_ice_covered_g(n) =  dataptr2d(ec-1,n) * (elev_u - topoglc_g(n)) / d_elev  &
-                              + dataptr2d(ec  ,n) * (topoglc_g(n) - elev_l) / d_elev
+                         data_ice_covered_g(n) =  dataptr2d(ec-1,n) * ((elev_u - topoglc_g(n)) / d_elev)  &
+                              + dataptr2d(ec  ,n) * ((topoglc_g(n) - elev_l) / d_elev)
                       end if
                       exit
                    end if

--- a/mediator/med_phases_prep_glc_mod.F90
+++ b/mediator/med_phases_prep_glc_mod.F90
@@ -937,7 +937,7 @@ contains
                 dataexp_g(n) = data_ice_covered_g(n)
              else
                 ! non ice-covered cells have bare land value
-                dataexp_g(n) = real(dataptr2d(1,n))
+                dataexp_g(n) = dataptr2d(1,n)
              end if
 
           end do  ! end of loop over land points


### PR DESCRIPTION
### Description of changes
Currently we use convective and resolved precipitation fields separately, but these are summed together anyway to give total precip fields. This is a problem for high resolution regional cases where convective schemes are turned off - convective precip isn't a thing! Best to just use total precip generally

### Specific notes

Contributors other than yourself, if any:

CMEPS Issues Fixed (include github issue #):
Addresses #19 
Are changes expected to change answers? (specify if bfb, different at roundoff, more substantial) 

Any User Interface Changes (namelist or namelist defaults changes)?

### Testing performed
Please describe the tests along with the target model and machine(s) 
If possible, please also added hashes that were used in the testing

