### PR TITLE
Use conservative remapping for ocn2atm variables

### DIFF
--- a/mediator/esmFldsExchange_accessesm_mod.F90
+++ b/mediator/esmFldsExchange_accessesm_mod.F90
@@ -332,22 +332,14 @@ module esmFldsExchange_accessesm_mod
       ! FIELDS TO ATMOSPHERE
       !=====================================================================
 
-      fldname = trim('So_t')
-      if (fldchk(is_local%wrap%FBExp(compatm), trim(fldname), rc=rc) .and. &
-         fldchk(is_local%wrap%FBImp(compocn, compocn), trim(fldname), rc=rc) &
-        ) then
-        call addmap_from(compocn, trim(fldname), compatm, mapbilnr, 'one', 'unset')
-        call addmrg_to(compatm, trim(fldname), mrg_from=compocn, mrg_fld=trim(fldname), mrg_type='copy')
-     end if
-
-      allocate(S_flds(2))
-      S_flds = [character(len=CS) :: 'So_u', 'So_v']
+      allocate(S_flds(3))
+      S_flds = [character(len=CS) :: 'So_t', 'So_u', 'So_v']
       do n = 1,size(S_flds)
          fldname = trim(S_flds(n))
          if (fldchk(is_local%wrap%FBExp(compatm), trim(fldname), rc=rc) .and. &
              fldchk(is_local%wrap%FBImp(compocn, compocn), trim(fldname), rc=rc) &
             ) then
-            call addmap_from(compocn, trim(fldname), compatm, mappatch, 'one', 'unset')
+            call addmap_from(compocn, trim(fldname), compatm, mapconsf, 'ofrac', 'unset')
             call addmrg_to(compatm, trim(fldname), mrg_from=compocn, mrg_fld=trim(fldname), mrg_type='copy')
          end if
       end do


### PR DESCRIPTION
This PR uses first order conservative remapping weighted by the ocean fraction for all ocn2atm fields. 

The default configuration of CM3 has 35 ocean grid points for every atmosphere grid point. 

When using bilinear remapping, for each atmosphere grid point, only the 4 closest ocean grid points are used to determine the remapped value. This means that the vast majority of ocean points aren't properly coupled, i.e. the atmosphere doesn't see the SST at these points.

Patch remapping uses slightly more points, but still has the same issue.

Using first order conservative remapping ensures that all ocean cells contribute to the coupled flux calculations.

Also, in general for downscaling, it's better to use averaging type methods over interpolation. 

Associate `access3-share` [PR](https://github.com/ACCESS-NRI/access3-share/pull/48).